### PR TITLE
V2 update

### DIFF
--- a/relayers.json
+++ b/relayers.json
@@ -8,16 +8,16 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.radarrelay.com/0x",
-                "sra_ws_endpoint": "wss://ws.radarrelay.com/0x",
+                "sra_http_endpoint": "https://api.radarrelay.com/0x/v2",
+                "sra_ws_endpoint": "wss://ws.radarrelay.com/0x/v2",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xa258b39954cef5cb142fd567a46cddb31a670124"]
                 }
             },
             {
                 "networkId": 42,
-                "sra_http_endpoint": "https://api.kovan.radarrelay.com/0x",
-                "sra_ws_endpoint": "wss://api.kovan.radarrelay.com/0x"
+                "sra_http_endpoint": "https://api.kovan.radarrelay.com/0x/v2",
+                "sra_ws_endpoint": "wss://api.kovan.radarrelay.com/0x/v2"
             }
         ]
     },
@@ -30,14 +30,15 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.ercdex.com/api/standard/1",
+                "sra_http_endpoint": "https://app.ercdex.com/api/v2/",
+                "sra_ws_endpoint": "wss://app.ercdex.com/ws",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0x58a5959a6c528c5d5e03f7b9e5102350e24005f1","0x7df569a165bee41ca74374c76bd888ea02dcc4a8","0xa71deef328b2c40d0e6525cd248ae749e9208dbb","0x3d974ce554fec1acd8d034f13b6640b300689a37","0xbd069e7ad0b7366ed1f0559dd8fe3e8efc0c4a72","0x4411c446756f8ed22343e8fbe8d24607027daffd","0xee2d43b8e4b57477acc2f4def265fe2887865ac0","0x5bf2c11b0aa0c752c6de6fed48dd56fed2a4286d","0x1dd43bbe2264234bccfbb88aadbde331d87719ee","0x8bf0785306eb675e38b742f59a7fcf05fccdf2b7","0x1956f5afa5d21000145e6cd2fa8ce3f52fa40875","0xa5b8d094f8364a9771c7a2287ee13efa08f847a4","0xc95bf3d3b4d6619119f3a8e29ec1d73ee801b9df","0x28f5cf7044f509af67f473c18b1f5f4f97fb4ce9","0x3b4ce2ea700ff327c3b4fe624f328c4106fd2885","0x3fa5f23d42847e49d242496ffe2a3c8fda66706c","0xd592cfa56f4c443fb27008329d67ed7d4edb59c0","0x173a2467cece1f752eb8416e337d0f0b58cad795"]
                 }
             },
             {
                 "networkId": 42,
-                "sra_http_endpoint": "https://api.ercdex.com/api/standard/42/v0/"
+                "sra_http_endpoint": "https://app.ercdex.com/api/v2/"
             }
         ]
     },
@@ -49,14 +50,14 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.openrelay.xyz",
+                "sra_http_endpoint": "https://api.openrelay.xyz/v2",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea"]
                 }
             },
             {
                 "networkId": 3,
-                "sra_http_endpoint": "https://api.openrelay.xyz",
+                "sra_http_endpoint": "https://api.openrelay.xyz/v2",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea"]
                 }
@@ -88,14 +89,12 @@
         "networks": [
             {
                 "networkId": 42,
-                "sra_http_endpoint": "https://kovan.amadeusrelay.org/api/v0/",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xf14958eca9f5b341f74916aacfb6e3d2fb9a4a15"]
                 }
             },
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.amadeusrelay.org/api/v0/",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0x0e8ba001a821f3ce0734763d008c9d7c957f5852"]
                 }
@@ -227,22 +226,18 @@
       "networks": [
           {
               "networkId": 1,
-              "sra_http_endpoint": "https://sra.bamboorelay.com/main",
               "static_order_fields": {
                   "fee_recipient_addresses": ["0x5dd835a893734b8d556eccf87800b76dda5aedc5"]
               }
           },
           {
               "networkId": 3,
-              "sra_http_endpoint": "https://sra.bamboorelay.com/ropsten"
           },
           {
               "networkId": 4,
-              "sra_http_endpoint": "https://sra.bamboorelay.com/rinkeby"
           },
           {
               "networkId": 42,
-              "sra_http_endpoint": "https://sra.bamboorelay.com/kovan"
           }
       ]
     },

--- a/relayers.json
+++ b/relayers.json
@@ -31,7 +31,7 @@
             {
                 "networkId": 1,
                 "sra_http_endpoint": "https://app.ercdex.com/api/v2/",
-                "sra_ws_endpoint": "wss://app.ercdex.com/ws",
+                "sra_ws_endpoint": "wss://app.ercdex.com/ws/v2",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0x58a5959a6c528c5d5e03f7b9e5102350e24005f1","0x7df569a165bee41ca74374c76bd888ea02dcc4a8","0xa71deef328b2c40d0e6525cd248ae749e9208dbb","0x3d974ce554fec1acd8d034f13b6640b300689a37","0xbd069e7ad0b7366ed1f0559dd8fe3e8efc0c4a72","0x4411c446756f8ed22343e8fbe8d24607027daffd","0xee2d43b8e4b57477acc2f4def265fe2887865ac0","0x5bf2c11b0aa0c752c6de6fed48dd56fed2a4286d","0x1dd43bbe2264234bccfbb88aadbde331d87719ee","0x8bf0785306eb675e38b742f59a7fcf05fccdf2b7","0x1956f5afa5d21000145e6cd2fa8ce3f52fa40875","0xa5b8d094f8364a9771c7a2287ee13efa08f847a4","0xc95bf3d3b4d6619119f3a8e29ec1d73ee801b9df","0x28f5cf7044f509af67f473c18b1f5f4f97fb4ce9","0x3b4ce2ea700ff327c3b4fe624f328c4106fd2885","0x3fa5f23d42847e49d242496ffe2a3c8fda66706c","0xd592cfa56f4c443fb27008329d67ed7d4edb59c0","0x173a2467cece1f752eb8416e337d0f0b58cad795"]
                 }
@@ -231,13 +231,13 @@
               }
           },
           {
-              "networkId": 3,
+              "networkId": 3
           },
           {
-              "networkId": 4,
+              "networkId": 4
           },
           {
-              "networkId": 42,
+              "networkId": 42
           }
       ]
     },

--- a/relayers.json
+++ b/relayers.json
@@ -8,7 +8,7 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.radarrelay.com/0x/v2",
+                "sra_http_endpoint": "https://api.radarrelay.com/0x/v2/",
                 "sra_ws_endpoint": "wss://ws.radarrelay.com/0x/v2",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xa258b39954cef5cb142fd567a46cddb31a670124"]
@@ -16,7 +16,7 @@
             },
             {
                 "networkId": 42,
-                "sra_http_endpoint": "https://api.kovan.radarrelay.com/0x/v2",
+                "sra_http_endpoint": "https://api.kovan.radarrelay.com/0x/v2/",
                 "sra_ws_endpoint": "wss://api.kovan.radarrelay.com/0x/v2"
             }
         ]
@@ -50,14 +50,14 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.openrelay.xyz/v2",
+                "sra_http_endpoint": "https://api.openrelay.xyz/v2/",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea"]
                 }
             },
             {
                 "networkId": 3,
-                "sra_http_endpoint": "https://api.openrelay.xyz/v2",
+                "sra_http_endpoint": "https://api.openrelay.xyz/v2/",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea"]
                 }
@@ -186,7 +186,6 @@
         "networks" : [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://mainnet-dexapi.tokenlon.im/v1",
                 "static_order_fields" : {
                     "fee_recipient_addresses" : ["0x6f7ae872e995f98fcd2a7d3ba17b7ddfb884305f"]
                  }
@@ -202,15 +201,12 @@
         "networks": [
             {
                 "networkId": 1,
-                "sra_http_endpoint": "https://api.sharkrelay.com/api",
-                "sra_ws_endpoint": "wss://app.sharkrelay.com/ws",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0x55890b06f0877a01bb5349d93b202961f8e27a9b"]
                 }
             },
             {
                 "networkId": 42,
-                "sra_ws_endpoint": "wss://kovan.sharkrelay.com/ws",
                 "static_order_fields": {
                     "fee_recipient_addresses": ["0x2e5a815fb70ae9e27188d9a4e72965e55b6f77b2"]
                 }


### PR DESCRIPTION
Removed non-V2 relayer endpoints. We can re-add them when they're upgraded.