### PR TITLE
Adjust tokenmom address field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:11.15
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/relayers.json
+++ b/relayers.json
@@ -429,7 +429,7 @@
             {
                 "networkId": 1,
                 "static_order_fields": {
-                    "fee_recipient_addresses": [
+                    "taker_addresses": [
                         "0x4a821aa1affbf7ee89a245bf750d1d7374e77409"
                     ]
                 }


### PR DESCRIPTION
Tokenmom is a matching relayer, see, e.g. https://0xtracker.com/fills/5d4b725c514bc00004d87e6c. The address listed in the registry should refer to the taker address.